### PR TITLE
Update default value of policy_groups variable to an empty object

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -112,5 +112,5 @@ variable "policy_groups" {
     priority   = optional(number)
   }))
   description = "(Optional) One or more policy_groups blocks as defined above."
-  default     = null
+  default     = {}
 }


### PR DESCRIPTION
## Description
This pull request makes a small change to the default value for the `policy_groups` variable in `variables.tf`, setting it to an empty object instead of null. This helps avoid potential issues with null handling in downstream code.