### PR TITLE
Update default value of policy_groups variable to null

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -112,5 +112,5 @@ variable "policy_groups" {
     priority   = optional(number)
   }))
   description = "(Optional) One or more policy_groups blocks as defined above."
-  default     = {}
+  default     = null
 }


### PR DESCRIPTION
This pull request makes a minor change to the `policy_groups` variable in `variables.tf`, updating its default value from an empty object to `null`. This change may improve compatibility with Terraform's handling of optional variables.