### PR TITLE
Reintroduce resource group

### DIFF
--- a/main.resource_group.tf
+++ b/main.resource_group.tf
@@ -1,8 +1,0 @@
-resource "azurerm_resource_group" "rg" {
-  count = var.deploy_resource_group ? 1 : 0
-
-  name       = var.resource_group_name
-  location   = var.location
-  managed_by = var.managed_by
-  tags       = try(var.tags.resource_group, null)
-}

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,12 @@
+resource "azurerm_resource_group" "rg" {
+  count = var.deploy_resource_group ? 1 : 0
+
+  name       = var.resource_group_name
+  location   = var.location
+  managed_by = var.managed_by
+  tags       = try(var.tags.resource_group, null)
+}
+
 resource "azurerm_vpn_server_configuration" "vpnsc" {
   name                     = var.name
   resource_group_name      = var.deploy_resource_group ? azurerm_resource_group.rg[0].name : var.resource_group_name

--- a/variables.tf
+++ b/variables.tf
@@ -112,5 +112,5 @@ variable "policy_groups" {
     priority   = optional(number)
   }))
   description = "(Optional) One or more policy_groups blocks as defined above."
-  default     = null
+  default     = {}
 }


### PR DESCRIPTION
This pull request primarily refactors the Terraform code to relocate the definition of the `azurerm_resource_group` resource and adjusts the default value for the `policy_groups` variable. The main goal is to improve code organization and ensure safer defaults for variable usage.

Resource definition refactor:

* Moved the `azurerm_resource_group` resource block from `main.resource_group.tf` to `main.tf` to consolidate resource definitions. [[1]](diffhunk://#diff-6858a1e19e02163f1030cb87adf0e12d2381951e657c8fcaee5b2d032982634dL1-L8) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR1-R9)

Variable default value update:

* Changed the default value of the `policy_groups` variable from `null` to an empty map `{}` in `variables.tf`, ensuring safer and more predictable behavior when the variable is not set.