### PR TITLE
Update default value of policy_groups variable to null in variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -112,5 +112,5 @@ variable "policy_groups" {
     priority   = optional(number)
   }))
   description = "(Optional) One or more policy_groups blocks as defined above."
-  default     = {}
+  default     = null
 }


### PR DESCRIPTION
This pull request makes a minor change to the default value of the `policy_groups` variable in `variables.tf`. The default is updated from an empty object to `null` to better reflect optionality and improve compatibility with Terraform's type system.