### PR TITLE
Update default value of policy_groups variable to null in variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -112,5 +112,5 @@ variable "policy_groups" {
     priority   = optional(number)
   }))
   description = "(Optional) One or more policy_groups blocks as defined above."
-  default     = {}
+  default     = null
 }


### PR DESCRIPTION
This pull request makes a minor update to the `policy_groups` variable in `variables.tf`, changing its default value from an empty object to `null`. This helps clarify the intended default state for the variable and may improve compatibility with certain Terraform behaviors.